### PR TITLE
Add zoom animation, fix #20

### DIFF
--- a/src/plugin/leaflet.canvas-markers.js
+++ b/src/plugin/leaflet.canvas-markers.js
@@ -148,7 +148,7 @@ function layerFactory(L) {
 
 
             if (map._zoomAnimated) {
-                map.of('zoomanim', this._animateZoom, this);
+                map.off('zoomanim', this._animateZoom, this);
             }
         },
 

--- a/src/plugin/leaflet.canvas-markers.js
+++ b/src/plugin/leaflet.canvas-markers.js
@@ -362,8 +362,6 @@ function layerFactory(L) {
         _initCanvas: function () {
 
             this._canvas = L.DomUtil.create('canvas', 'leaflet-canvas-icon-layer leaflet-layer');
-            var originProp = L.DomUtil.testProp(['transformOrigin', 'WebkitTransformOrigin', 'msTransformOrigin']);
-            this._canvas.style[originProp] = '50% 50%';
 
             var size = this._map.getSize();
             this._canvas.width = size.x;

--- a/src/plugin/leaflet.canvas-markers.js
+++ b/src/plugin/leaflet.canvas-markers.js
@@ -129,6 +129,10 @@ function layerFactory(L) {
 
             map.on('click', this._executeListeners, this);
             map.on('mousemove', this._executeListeners, this);
+
+            if (map._zoomAnimated) {
+                map.on('zoomanim', this._animateZoom, this);
+            }
         },
 
         onRemove: function (map) {
@@ -141,6 +145,11 @@ function layerFactory(L) {
 
             map.off('moveend', this._reset, this);
             map.off('resize',this._reset,this);
+
+
+            if (map._zoomAnimated) {
+                map.of('zoomanim', this._animateZoom, this);
+            }
         },
 
         addTo: function (map) {
@@ -154,6 +163,13 @@ function layerFactory(L) {
             this._latlngMarkers = null;
             this._markers = null;
             this._redraw(true);
+        },
+
+        _animateZoom: function(event) {
+            var scale = this._map.getZoomScale(event.zoom);
+            var offset = this._map._latLngBoundsToNewLayerBounds(this._map.getBounds(), event.zoom, event.center).min;
+
+            L.DomUtil.setTransform(this._canvas, offset, scale);
         },
 
         _addMarker: function(marker,latlng,isDisplaying) {


### PR DESCRIPTION
Fixed animation on zoom (see #20) by adding `zoomanim` event handler, which applies CSS transformation to `canvas` element similar to how Leaflet's `ImageOverlay` [does it](https://github.com/Leaflet/Leaflet/blob/master/src/layer/ImageOverlay.js#L216-L221).

![after](https://user-images.githubusercontent.com/810702/45436276-4d289180-b6aa-11e8-8b52-81d8387fda07.gif)

Also removed `transform-origin: 50% 50%` from `canvas` element since it only got in the way of calculations for zoom animation - the only place where CSS transformations were used.